### PR TITLE
[PTT-79] Remove CI step from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,11 @@
-FROM circleci/node:10.14.2 as builder
-
-RUN sudo apt-get -y install --no-install-recommends libunwind8=1.1-4.1
-
-WORKDIR /usr/src/app
-
-COPY /src /usr/src/app/src
-COPY /package.json /usr/src/app/package.json
-COPY /tsconfig.json /usr/src/app/tsconfig.json
-COPY /yarn.lock /usr/src/app/yarn.lock
-
-RUN sudo chmod -R 777 /usr/src/app \
-  && yarn install \
-  && yarn build
-
 FROM node:10.14.2-alpine
 LABEL maintainer="https://pagopa.gov.it"
 
 WORKDIR /usr/src/app
 
 COPY /package.json /usr/src/app/package.json
-COPY --from=builder /usr/src/app/dist /usr/src/app/dist
-COPY --from=builder /usr/src/app/node_modules /usr/src/app/node_modules
+COPY /dist /usr/src/app/dist
+COPY /node_modules /usr/src/app/node_modules
 
 EXPOSE 8080
 


### PR DESCRIPTION
## Description
This PR proposes to strip down the docker file to remove CI step via a CircleCi image. The CI step can be accomplished by `yarn install && yarn build` in a local environment, or by similar tasks in an Azure DevOps pipeline. 
Moreover, the resulting Dockerfile can be used to deploy the service as a docker image in a container registry.

## Tests
Manual tests via `docker-compose up --build`