### PR TITLE
Upgrade io-spid-commons and fix opaque token level

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ In order to run SPID Login microservice in a local environment you must:
 - Take care about the values setted for SP `SERVER_PORT` and the metadata endpoint registered in `spid-testenv2` config yaml
 - build the project by running `yarn build`
 - Run `docker compose --env-file .env up --build` or `yarn docker:start`
+- Call Endpoint to refresh IDP metadata e.g. `curl -L -X GET 'http://localhost:9090/refresh'`
 
 ## JWT Support
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,12 +26,15 @@ services:
 
     spid-testenv2:
         container_name: spid-testenv2
-        image: italia/spid-testenv2:1.1.0
+        image: italia/spid-testenv2:latest
+        restart: unless-stopped
         ports:
             - "8088:8088"
         volumes:
             - "./conf-testenv:/app/conf"
             - "./certs:/app/certs:ro"
+        depends_on: 
+            - backend
         networks:
             - spid-net
      

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "typescript": "^3.7.0"
   },
   "dependencies": {
-    "@pagopa/io-spid-commons": "^6.4.0",
+    "@pagopa/io-spid-commons": "^6.5.0",
     "@pagopa/ts-commons": "^9.1.0",
     "@types/redis": "^2.8.14",
     "crypto": "^1.0.1",

--- a/src/app.ts
+++ b/src/app.ts
@@ -174,9 +174,9 @@ const acs: AssertionConsumerServiceT = async user => {
                 )
               )
             : taskEither.of(_)
-          : fromEither(TokenUserL2.decode(_)).mapLeft(errs =>
-              toResponseErrorInternal(errorsToError(errs))
-            )
+          : fromEither(
+              TokenUserL2.decode({ ..._, level: "L2" })
+            ).mapLeft(errs => toResponseErrorInternal(errorsToError(errs)))
       )
       .chain(tokenUser =>
         generateToken(tokenUser).mapLeft(toResponseErrorInternal)

--- a/yarn.lock
+++ b/yarn.lock
@@ -360,10 +360,10 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@pagopa/io-spid-commons@^6.4.0":
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-spid-commons/-/io-spid-commons-6.4.0.tgz#4b470e7ebf3858ce9677c670e6eab0744c80467c"
-  integrity sha512-tEXS5Rgv0dfdm/rkEB4RUPPnzrxW/AWFCJFZK+mC5Fm6wEJjyxD1e3D17JQ4ot4RUcMUlxFcHbDPAqE0Tq5Kkg==
+"@pagopa/io-spid-commons@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-spid-commons/-/io-spid-commons-6.5.0.tgz#c71c8bbad75fbb54d8351084269e2d7e6993f9e4"
+  integrity sha512-TmDAD2lwRXllPiCXVzFKB+dYR1fuYrhD8RZXAdWwrxAd6q4hMB3NUgOWrY+39eW7H+QKAIO79OWwYArUPgS0pw==
   dependencies:
     "@types/redis" "^2.8.14"
     date-fns "^1.30.1"


### PR DESCRIPTION
This PR upgrades io-spid-commons version to `6.5.0` and fix the default behaviour while using opaque token without attribute authority.