### PR TITLE
[SELC-299] remove max lenght from title of error

### DIFF
--- a/openapi/userregistry.yaml
+++ b/openapi/userregistry.yaml
@@ -231,8 +231,6 @@ definitions:
       title:
         description: A short, summary of the problem type. Written in english and readable
         example: Service Unavailable
-        maxLength: 64
-        pattern: ^[ -~]{0,64}$
         type: string
       detail:
         description: A human readable explanation of the problem.


### PR DESCRIPTION
User Registry expose that maxLength for title field on Problem definition, but for every response return a longer title