### PR TITLE
feat(HSL-15): adds parameter JWT_TOKEN_JTI_SPID in env to create jti reflecting the spidRequestId

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ Although configurations have been designed to be generic, each storage keeps its
 
 #### Specific configuration for `azurestorage`
 
-| name                                  | description                                | values | required |
-| ------------------------------------- | ------------------------------------------ | ------ | -------- |
+| name                                 | description                                | values | required |
+| -------------------------------------| ------------------------------------------ | ------ | -------- |
 | `SPID_LOGS_STORAGE_CONNECTION_STRING` | Connection string for the external storage | string | yes      |
 
 #### Specific configuration for `awss3`
@@ -92,6 +92,11 @@ We use `AWS` SDK defaults for connecting to the storage. Please refer to the ori
 | `SPID_LOGS_STORAGE_ENDPOINT` | Optional endpoint for target S3 service. Meant to be used in testing environments. If empty, `AWS`'s default will be used. We must provide a fully qualified ENDPOINT with URL, PROTOCOL, HOSTNAME | string | yes |
 | `SPID_LOGS_STORAGE_CONTAINER_REGION` | Optional region for target S3 service. | yes |
 | `SPID_LOGS_STORAGE_CONNECTION_TIMEOUT` | Optional timeout value for connecting to the storage, in milliseconds. Default: 60000  | no |
+
+## Project specific configuration
+| name                 | description                                                | values  | required |
+|----------------------|------------------------------------------------------------|---------|----------|
+| `JWT_TOKEN_JTI_SPID` | Optional parameter that allow JWT jti reflect the spidRequestId. Default: false | boolean | no       |
 
 # Architecture
 

--- a/e2e/scenarios/with-aws-s3/env.scenario
+++ b/e2e/scenarios/with-aws-s3/env.scenario
@@ -38,6 +38,7 @@ JWT_TOKEN_ISSUER=SPID
 JWT_TOKEN_AUDIENCE=https://localhost
 JWT_TOKEN_PRIVATE_KEY=""
 JWT_TOKEN_KID=key-id-for-your-jwt-key
+JWT_TOKEN_JTI_SPID=true
 
 ENABLE_ADE_AA=false
 ADE_AA_API_ENDPOINT=http://ade-aa-ms-mock:3000

--- a/src/app.ts
+++ b/src/app.ts
@@ -42,6 +42,7 @@ import { getConfigOrThrow } from "./utils/config";
 import {
   errorsToError,
   toCommonTokenUser,
+  toRequestId,
   toResponseErrorInternal,
   toTokenUserL2
 } from "./utils/conversions";
@@ -246,9 +247,11 @@ const acs: AssertionConsumerServiceT = async user =>
     }),
     TE.chainW(tokenUser => {
       logger.info("ACS | Generating token");
+      const requestId = config.JWT_TOKEN_JTI_SPID
+        ? toRequestId(user as Record<string, unknown>)
+        : undefined;
       return pipe(
-        tokenUser,
-        generateToken,
+        generateToken(tokenUser, requestId),
         TE.mapLeft(toResponseErrorInternal)
       );
     }),

--- a/src/handlers/token.ts
+++ b/src/handlers/token.ts
@@ -75,7 +75,8 @@ export const getTokenExpiration = (
     : config.TOKEN_EXPIRATION;
 
 export const generateToken = (
-  tokenUser: TokenUser | TokenUserL2
+  tokenUser: TokenUser | TokenUserL2,
+  requestId?: NonEmptyString
 ): TE.TaskEither<
   Error,
   { readonly tokenStr: string; readonly tokenUser: TokenUser | TokenUserL2 }
@@ -91,7 +92,8 @@ export const generateToken = (
               tokenExpiration,
               config.JWT_TOKEN_ISSUER,
               config.JWT_TOKEN_KID,
-              config.JWT_TOKEN_AUDIENCE
+              config.JWT_TOKEN_AUDIENCE,
+              requestId
             ),
             TE.mapLeft(() => new Error("Error generating JWT Token")),
             TE.map(_ => ({ tokenStr: _, tokenUser }))

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -219,6 +219,7 @@ export const JWTParams = t.union([
     t.interface({
       ENABLE_JWT: t.literal(true),
       JWT_TOKEN_ISSUER: NonEmptyString,
+      JWT_TOKEN_JTI_SPID: t.boolean,
       JWT_TOKEN_PRIVATE_KEY: NonEmptyString
     }),
     t.partial({
@@ -229,7 +230,8 @@ export const JWTParams = t.union([
   ]),
   t.interface({
     ENABLE_JWT: t.literal(false),
-    ENABLE_USER_REGISTRY: t.literal(false)
+    ENABLE_USER_REGISTRY: t.literal(false),
+    JWT_TOKEN_JTI_SPID: t.boolean
   })
 ]);
 export type JWTParams = t.TypeOf<typeof JWTParams>;
@@ -334,6 +336,11 @@ const errorOrConfig: t.Validation<IConfig> = IConfig.decode({
     )
   ),
   INCLUDE_SPID_USER_ON_INTROSPECTION: pipe(
+    O.fromNullable(process.env.INCLUDE_SPID_USER_ON_INTROSPECTION),
+    O.map(_ => _.toLowerCase() === "true"),
+    O.getOrElse(() => false)
+  ),
+  JWT_TOKEN_JTI_SPID: pipe(
     O.fromNullable(process.env.INCLUDE_SPID_USER_ON_INTROSPECTION),
     O.map(_ => _.toLowerCase() === "true"),
     O.getOrElse(() => false)

--- a/src/utils/conversions.ts
+++ b/src/utils/conversions.ts
@@ -9,6 +9,7 @@ import { Errors } from "io-ts";
 import * as t from "io-ts";
 import { errorsToReadableMessages } from "@pagopa/ts-commons/lib/reporters";
 import { pipe } from "fp-ts/lib/function";
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import {
   CommonTokenUser,
   FISCAL_NUMBER_INTERNATIONAL_PREFIX,
@@ -80,3 +81,6 @@ export const mapDecoding = <S, A>(
   toDecode: unknown
 ): TE.TaskEither<Error, A> =>
   pipe(toDecode, type.decode, E.mapLeft(errorsToError), TE.fromEither);
+
+export const toRequestId = (user: Record<string, unknown>): NonEmptyString =>
+  user.inResponseTo as NonEmptyString;

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -34,7 +34,8 @@ export const getUserJwt = (
   tokenTtlSeconds: NonNegativeInteger,
   issuer: NonEmptyString,
   keyid?: NonEmptyString,
-  audience?: NonEmptyString
+  audience?: NonEmptyString,
+  requestId?: NonEmptyString
   // eslint-disable-next-line max-params
 ): TE.TaskEither<Error, string> =>
   pipe(
@@ -47,7 +48,7 @@ export const getUserJwt = (
           audience,
           expiresIn: `${tokenTtlSeconds} seconds`,
           issuer,
-          jwtid: ulid(),
+          jwtid: requestId ?? ulid(),
           keyid,
           subject: tokenUser.id
         }),


### PR DESCRIPTION
## Description
This PR adds an optional parameter to env variables, JWT_TOKEN_JTI_SPID that allows to pass conditionally the `requestId` to the `generateToken` function and subsequently to the `jwt.sign` function to allow the `jti` to take that value instead of being generated as a `ULID`.


#### List of Changes
- Adds JWT_TOKEN_JTI_SPID env variable to change jti value conditionally
- Adds requestId value to generateToken and jti.sign functions
- Adds the new parameter description and use case in the README

#### Motivation and Context
This changes ensure that the jti is configurable using an env variable, as required from the project Piattaforma Notifiche.

#### How Has This Been Tested?
I tested this changes by running the end-to-end tests with the basic and with-aws-s3 scenarios.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. (README file)
