### PR TITLE
[#IOPID-832] Enable hub-spid-login to store plain text SAML request/response

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ It is possible to log SAML requests and responses for each successful login. Ass
 |name|description|values|required|
 |-|-|-|-|
 |`ENABLE_SPID_ACCESS_LOGS`|Whether log or not SAML assertions|`true` or `false`| yes|
-|`SPID_LOGS_PUBLIC_KEY`|Key used to encypt SAML assertions payload| string | yes if `ENABLE_SPID_ACCESS_LOGS=true`|
+|`SPID_LOGS_ENABLE_PAYLOAD_ENCRYPTION`|Whether encript payload before storing or not|`true` or `false`| no, default `true`|
+|`SPID_LOGS_PUBLIC_KEY`|Key used to encypt SAML assertions payload| string | yes if `ENABLE_SPID_ACCESS_LOGS=true` and `SPID_LOGS_ENABLE_PAYLOAD_ENCRYPTION=true`|
 |`SPID_LOGS_STORAGE_KIND`|The kind of storage to be used. Default: `azurestorage` for backward compatibility| See `config.ts` for all supported storages | yes if `ENABLE_SPID_ACCESS_LOGS=true`|
 |`SPID_LOGS_STORAGE_CONTAINER_NAME`|Name of the container to store files into | string | yes if `ENABLE_SPID_ACCESS_LOGS=true`|
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ It is possible to log SAML requests and responses for each successful login. Ass
 |name|description|values|required|
 |-|-|-|-|
 |`ENABLE_SPID_ACCESS_LOGS`|Whether log or not SAML assertions|`true` or `false`| yes|
-|`SPID_LOGS_ENABLE_PAYLOAD_ENCRYPTION`|Whether encript payload before storing or not|`true` or `false`| no, default `true`|
+|`SPID_LOGS_ENABLE_PAYLOAD_ENCRYPTION`|Whether to encrypt the payload before storing it or not|`true` or `false`| no, default `true`|
 |`SPID_LOGS_PUBLIC_KEY`|Key used to encypt SAML assertions payload| string | yes if `ENABLE_SPID_ACCESS_LOGS=true` and `SPID_LOGS_ENABLE_PAYLOAD_ENCRYPTION=true`|
 |`SPID_LOGS_STORAGE_KIND`|The kind of storage to be used. Default: `azurestorage` for backward compatibility| See `config.ts` for all supported storages | yes if `ENABLE_SPID_ACCESS_LOGS=true`|
 |`SPID_LOGS_STORAGE_CONTAINER_NAME`|Name of the container to store files into | string | yes if `ENABLE_SPID_ACCESS_LOGS=true`|

--- a/src/app.ts
+++ b/src/app.ts
@@ -147,7 +147,7 @@ if (config.ALLOW_CORS) {
 const doneCb = config.ENABLE_SPID_ACCESS_LOGS
   ? accessLogHandler(
       createAccessLogWriter(config),
-      createAccessLogEncrypter(config.SPID_LOGS_PUBLIC_KEY),
+      createAccessLogEncrypter(config),
       createMakeSpidLogBlobName(config)
     )
   : (ip: string | null, request: string, response: string): void => {

--- a/src/types/access_log.ts
+++ b/src/types/access_log.ts
@@ -38,7 +38,25 @@ export const EncryptedSpidBlobItem = t.intersection([
   })
 ]);
 
-export const SpidBlobItem = EncryptedSpidBlobItem;
+/**
+ * Payload of the stored blob item
+ * (one for each SPID request or response).
+ */
+export const PlainTextSpidBlobItem = t.intersection([
+  SpidBlobItemBase,
+  t.interface({
+    // XML payload of the SPID Request
+    SAMLRequest: NonEmptyString,
+
+    // XML payload of the SPID Response
+    SAMLResponse: NonEmptyString
+  })
+]);
+
+export const SpidBlobItem = t.union([
+  EncryptedSpidBlobItem,
+  PlainTextSpidBlobItem
+]);
 
 export type SpidBlobItem = t.TypeOf<typeof SpidBlobItem>;
 

--- a/src/types/access_log.ts
+++ b/src/types/access_log.ts
@@ -3,6 +3,7 @@ import { EncryptedPayload } from "@pagopa/ts-commons/lib/encrypt";
 import {
   FiscalCode,
   IPString,
+  NonEmptyString,
   PatternString
 } from "@pagopa/ts-commons/lib/strings";
 import * as t from "io-ts";

--- a/src/utils/__tests__/access_log.test.ts
+++ b/src/utils/__tests__/access_log.test.ts
@@ -22,7 +22,7 @@ import {
   IPString,
   NonEmptyString
 } from "@pagopa/ts-commons/lib/strings";
-import { SpidBlobItem, SpidLogMsg } from "../../types/access_log";
+import { SpidBlobItem } from "../../types/access_log";
 import * as E from "fp-ts/lib/Either";
 import * as TE from "fp-ts/lib/TaskEither";
 import * as O from "fp-ts/lib/Option";
@@ -164,10 +164,11 @@ describe("toSpidBlobItem", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
-  it("should build encrypted Blob items from  valid messages", () => {
-    const blobItemOrError = createAccessLogEncrypter(aPublicKey)(
-      aValidSpidLogMessage
-    );
+  it("should build encrypted Blob items from valid messages, when encryption is required", () => {
+    const blobItemOrError = createAccessLogEncrypter({
+      SPID_LOGS_ENCRYPT_PAYLOAD: true as const,
+      SPID_LOGS_PUBLIC_KEY: aPublicKey
+    })(aValidSpidLogMessage);
 
     if (E.isRight(blobItemOrError)) {
       // both request and response payload must be encypted
@@ -215,9 +216,10 @@ describe("toSpidBlobItem", () => {
       E.left(new Error("unexpected"))
     );
 
-    const blobItemOrError = createAccessLogEncrypter(aPublicKey)(
-      aValidSpidLogMessage
-    );
+    const blobItemOrError = createAccessLogEncrypter({
+      SPID_LOGS_ENCRYPT_PAYLOAD: true as const,
+      SPID_LOGS_PUBLIC_KEY: aPublicKey
+    })(aValidSpidLogMessage);
 
     if (E.isRight(blobItemOrError)) {
       fail(`expected to be left`);
@@ -236,7 +238,10 @@ describe("createAzureStorageAccessLogWriter", () => {
   const mockedContainerName = "aContainer" as NonEmptyString;
   const mockedPublicKey = "aPublicKey" as NonEmptyString;
   const mockedSpidBLogItem = pipe(
-    createAccessLogEncrypter(mockedPublicKey)(aValidSpidLogMessage),
+    createAccessLogEncrypter({
+      SPID_LOGS_ENCRYPT_PAYLOAD: true as const,
+      SPID_LOGS_PUBLIC_KEY: mockedPublicKey
+    })(aValidSpidLogMessage),
     E.getOrElseW(err => {
       fail(
         `Cannot build SpidBlobItem, please check either the function or mock data, ${err.message}`

--- a/src/utils/__tests__/access_log.test.ts
+++ b/src/utils/__tests__/access_log.test.ts
@@ -166,7 +166,7 @@ describe("toSpidBlobItem", () => {
   });
   it("should build encrypted Blob items from valid messages, when encryption is required", () => {
     const blobItemOrError = createAccessLogEncrypter({
-      SPID_LOGS_ENCRYPT_PAYLOAD: true as const,
+      SPID_LOGS_ENABLE_PAYLOAD_ENCRYPTION: true as const,
       SPID_LOGS_PUBLIC_KEY: aPublicKey
     })(aValidSpidLogMessage);
 
@@ -213,7 +213,7 @@ describe("toSpidBlobItem", () => {
 
   it("should build Blob items from valid messages with no encryption, if not required", () => {
     const blobItemOrError = createAccessLogEncrypter({
-      SPID_LOGS_ENCRYPT_PAYLOAD: false as const
+      SPID_LOGS_ENABLE_PAYLOAD_ENCRYPTION: false as const
     })(aValidSpidLogMessage);
 
     if (E.isRight(blobItemOrError)) {
@@ -246,7 +246,7 @@ describe("toSpidBlobItem", () => {
     );
 
     const blobItemOrError = createAccessLogEncrypter({
-      SPID_LOGS_ENCRYPT_PAYLOAD: true as const,
+      SPID_LOGS_ENABLE_PAYLOAD_ENCRYPTION: true as const,
       SPID_LOGS_PUBLIC_KEY: aPublicKey
     })(aValidSpidLogMessage);
 
@@ -268,7 +268,7 @@ describe("createAzureStorageAccessLogWriter", () => {
   const mockedPublicKey = "aPublicKey" as NonEmptyString;
   const mockedSpidBLogItem = pipe(
     createAccessLogEncrypter({
-      SPID_LOGS_ENCRYPT_PAYLOAD: true as const,
+      SPID_LOGS_ENABLE_PAYLOAD_ENCRYPTION: true as const,
       SPID_LOGS_PUBLIC_KEY: mockedPublicKey
     })(aValidSpidLogMessage),
     E.getOrElseW(err => {

--- a/src/utils/access_log.ts
+++ b/src/utils/access_log.ts
@@ -14,7 +14,8 @@ import { md } from "node-forge";
 import {
   EncryptedSpidBlobItem,
   SpidBlobItem,
-  SpidLogMsg
+  SpidLogMsg,
+  PlainTextSpidBlobItem
 } from "../types/access_log";
 import { upsertBlobFromObject } from "./blob";
 import {
@@ -125,14 +126,17 @@ export const createAccessLogEncrypter = (
   } else {
     return pipe(
       sequenceS(E.Applicative)({
-        requestPayload: NonEmptyString.decode(spidLogMsg.requestPayload),
-        responsePayload: NonEmptyString.decode(spidLogMsg.responsePayload)
+        SAMLRequest: NonEmptyString.decode(spidLogMsg.requestPayload),
+        SAMLResponse: NonEmptyString.decode(spidLogMsg.responsePayload)
       }),
       E.mapLeft(errorsToError),
       E.map(item => ({
         ...spidLogMsg,
         ...item
-      }))
+      })),
+      E.chainW(
+        flow(t.exact(PlainTextSpidBlobItem).decode, E.mapLeft(errorsToError))
+      )
     );
   }
 };

--- a/src/utils/access_log.ts
+++ b/src/utils/access_log.ts
@@ -106,7 +106,7 @@ export const createAccessLogEncrypter = (
 ): AccessLogEncrypter => (
   spidLogMsg: SpidLogMsg
 ): E.Either<Error, SpidBlobItem> => {
-  if (storageConfig.SPID_LOGS_ENCRYPT_PAYLOAD) {
+  if (storageConfig.SPID_LOGS_ENABLE_PAYLOAD_ENCRYPTION) {
     const encrypt = curry(toEncryptedPayload)(
       storageConfig.SPID_LOGS_PUBLIC_KEY
     );

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -229,9 +229,9 @@ const SpidLogsStorageAwsS3 = t.intersection([
 
 export type EncryptionConfiguration = t.TypeOf<typeof EncryptionConfiguration>;
 export const EncryptionConfiguration = t.union([
-  t.interface({ SPID_LOGS_ENCRYPT_PAYLOAD: t.literal(false) }),
+  t.interface({ SPID_LOGS_ENABLE_PAYLOAD_ENCRYPTION: t.literal(false) }),
   t.interface({
-    SPID_LOGS_ENCRYPT_PAYLOAD: t.literal(true),
+    SPID_LOGS_ENABLE_PAYLOAD_ENCRYPTION: t.literal(true),
     SPID_LOGS_PUBLIC_KEY: NonEmptyString
   })
 ]);
@@ -497,8 +497,8 @@ const errorOrConfig: t.Validation<IConfig> = IConfig.decode({
     ),
     E.toUnion
   ),
-  SPID_LOGS_ENCRYPT_PAYLOAD: pipe(
-    O.fromNullable(process.env.SPID_LOGS_ENCRYPT_PAYLOAD),
+  SPID_LOGS_ENABLE_PAYLOAD_ENCRYPTION: pipe(
+    O.fromNullable(process.env.SPID_LOGS_ENABLE_PAYLOAD_ENCRYPTION),
     O.map(_ => _.toLowerCase() === "true"),
     O.getOrElse(() => true)
   ),

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -227,6 +227,15 @@ const SpidLogsStorageAwsS3 = t.intersection([
   })
 ]);
 
+export type EncryptionConfiguration = t.TypeOf<typeof EncryptionConfiguration>;
+export const EncryptionConfiguration = t.union([
+  t.interface({ SPID_LOGS_ENCRYPT_PAYLOAD: t.literal(false) }),
+  t.interface({
+    SPID_LOGS_ENCRYPT_PAYLOAD: t.literal(true),
+    SPID_LOGS_PUBLIC_KEY: NonEmptyString
+  })
+]);
+
 export type SpidLogsStorageConfiguration = t.TypeOf<
   typeof SpidLogsStorageConfiguration
 >;
@@ -239,9 +248,9 @@ const SpidLogsParams = t.union([
   // When Logs are enabled, storage configuration is mandatory
   t.intersection([
     t.interface({
-      ENABLE_SPID_ACCESS_LOGS: t.literal(true),
-      SPID_LOGS_PUBLIC_KEY: NonEmptyString
+      ENABLE_SPID_ACCESS_LOGS: t.literal(true)
     }),
+    EncryptionConfiguration,
     SpidLogsStorageConfiguration
   ]),
   t.interface({
@@ -487,6 +496,11 @@ const errorOrConfig: t.Validation<IConfig> = IConfig.decode({
       )
     ),
     E.toUnion
+  ),
+  SPID_LOGS_ENCRYPT_PAYLOAD: pipe(
+    O.fromNullable(process.env.SPID_LOGS_ENCRYPT_PAYLOAD),
+    O.map(_ => _.toLowerCase() === "true"),
+    O.getOrElse(() => true)
   ),
   SPID_LOGS_STORAGE_NAME_HIDE_FISCALCODE: pipe(
     O.fromNullable(process.env.SPID_LOGS_STORAGE_NAME_HIDE_FISCALCODE),


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

This PR depends on #93 

#### List of Changes
<!--- Describe your changes in detail -->

- Add new `SPID_LOGS_ENABLE_PAYLOAD_ENCRYPTION` variable. The default is `true` for backward compatibility.
- Use plain text values for SAML request/response, when `SPID_LOGS_ENABLE_PAYLOAD_ENCRYPTION` is set  to `false`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Enable hub-spid-login to store plain text SAML request/response. This is useful for enabling BYOK on storage (both Az storage and S3).

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit test, manual tests

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
