### PR TITLE
Rised timeout for saml response as asked from security for testing

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -109,7 +109,7 @@ const serviceProviderConfig: IServiceProviderConfig = {
 
 const samlConfig: SamlConfig = {
   RACComparison: "minimum",
-  acceptedClockSkewMs: 2000,
+  acceptedClockSkewMs: 3600000,
   attributeConsumingServiceIndex: "0",
   authnContext: config.AUTH_N_CONTEXT,
   callbackUrl: `${config.ACS_BASE_URL}${config.ENDPOINT_ACS}`,


### PR DESCRIPTION
#### List of Changes
Increased `acceptedClockSkewMs` to allow verifying saml response for 1 hour.

#### Motivation and Context
This is needed for security tests.